### PR TITLE
add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "muid",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "mini unique id generator",
   "main": "index.js",
   "scripts": {
     "test": "node test",
     "readme": "pretty-readme > readme.md"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chunpu/muid.git"
   },
   "author": "chunpu",
   "license": "ISC"


### PR DESCRIPTION
This enables npm to link to the GitHub repo. Also, when you don't have a repository field, npm gives you a warning on install.
